### PR TITLE
fix for php artisan config:cache

### DIFF
--- a/src/Console/Commands/RatchetServerCommand.php
+++ b/src/Console/Commands/RatchetServerCommand.php
@@ -148,7 +148,7 @@ class RatchetServerCommand extends Command
     {
         $this->serverInstance = new IpBlackList($this->serverInstance);
 
-        foreach (config('ratchet.blackList')->all() as $host) {
+        foreach (config('ratchet.blackList') as $host) {
             $this->serverInstance->blockAddress($host);
         }
     }

--- a/src/config/ratchet.php
+++ b/src/config/ratchet.php
@@ -20,7 +20,7 @@ return [
         'onMessage' => '20:1',
      ],
     'abortOnMessageThrottle' => false,
-    'blackList'              => collect([]),
+    'blackList'              => [],
     'zmq'                    => [
         'host'   => '127.0.0.1',
         'port'   => 5555,


### PR DESCRIPTION
Running `php artisan config:cache` will result in exceptions being thrown when running any future artisan commands. This fixes the issue by iterating over an array rather than a collection.