### PR TITLE
fix to work with laravel 5.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "php": ">=7.1.0",
         "ext-zmq": "*",
         "cboden/ratchet": "^0.4",
-        "graham-campbell/throttle": "^6.0",
+        "graham-campbell/throttle": "^7.0",
         "illuminate/console": "^5.5",
         "illuminate/support": "^5.5",
         "react/zmq": "0.2.*|0.3.*"


### PR DESCRIPTION
the throttle package in this version which is marked to work with larvel 5.6 was set to a 5.5 version of throttle. 7.0 introduced laravel 5.6 support